### PR TITLE
Update Gradle Namespace

### DIFF
--- a/sdk/build.gradle.kts
+++ b/sdk/build.gradle.kts
@@ -21,7 +21,7 @@ if (dotenv["GPG_KEY_ID"].isNullOrEmpty() || dotenv["GPG_PASSPHRASE"].isNullOrEmp
 }
 
 android {
-    namespace = "io.github.pushlytic"
+    namespace = "com.pushlytic.sdk"
     compileSdk = 35
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11


### PR DESCRIPTION
### Summary
This PR updates the namespace for the `sdk` module to `com.pushlytic.sdk` while keeping the Maven `groupId` unchanged as `io.github.pushlytic`.

### Changes
- Updated the Android `namespace` in the `sdk` Gradle configuration to `com.pushlytic.sdk` to reflect the package structure.
- Retained the Maven `groupId` in the publishing block as `io.github.pushlytic` for consistency with the project repository and existing namespace verification.
- Ensured the build configurations, including `BuildConfig` generation, are consistent with the namespace update.

### Reason for Change
This change improves the Android package hierarchy without affecting the Maven publishing configuration, ensuring consistency between the Android namespace and the expected package structure for consumers of the SDK.

### Testing
- Verified `./gradlew :sdk:assembleRelease` builds successfully.
- Tested `./gradlew publishToMavenLocal` to ensure proper artifact generation and publishing with the updated namespace.
