### PR TITLE
Fix: Add explicit dependency for metadata file generation

### DIFF
--- a/sdk/build.gradle.kts
+++ b/sdk/build.gradle.kts
@@ -298,6 +298,10 @@ afterEvaluate {
         )
         sign(publishing.publications["release"])
     }
+
+    tasks.named("generateMetadataFileForReleasePublication") {
+        dependsOn(tasks.named("androidSourcesJar"))
+    }
 }
 
 configurations {


### PR DESCRIPTION
This PR resolves a build issue where the :sdk:generateMetadataFileForReleasePublication task failed due to an implicit dependency on the :sdk:androidSourcesJar task. By explicitly declaring this dependency, we ensure that the build order is correct and that all necessary files are available during the publication process.

Changes:
Added a dependsOn statement for generateMetadataFileForReleasePublication to depend on androidSourcesJar.
Placed the fix within the afterEvaluate block to ensure tasks are configured correctly.