### PR TITLE
Update dependency documentation to reflect correct Maven coordinates

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The Pushlytic Android SDK is published on [Maven Central](https://search.maven.o
 1. Add the Pushlytic Android SDK dependency to your `build.gradle` file:
    ```kotlin
    dependencies {
-       implementation("com.pushlytic.sdk:sdk:0.1.0")
+       implementation("com.pushlytic:sdk:0.1.0")
    }
    ```
 2. Sync your project with Gradle files.


### PR DESCRIPTION
This PR updates the documentation for integrating the Pushlytic Android SDK to ensure accurate dependency instructions.

Updated the Gradle dependency section in the documentation to use the correct groupId, artifactId, and version:
implementation("com.pushlytic:sdk:0.1.0")
