### PR TITLE
feat(android): add device id to grpc metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,14 @@
 # Changelog
 All notable changes to the Pushlytic Android SDK will be documented in this file.
 
-## [0.1.0] - 2024-02-24
+## [0.1.1] - 2025-01-11
+### Added
+- Device ID tracking in gRPC metadata using ANDROID_ID
+- Cache mechanism for device ID with lazy initialization
+- UUID fallback for edge cases
+- Parity with iOS's identifierForVendor implementation
+
+## [0.1.0] - 2024-12-01
 ### Beta Release
 First beta release of Pushlytic Android SDK! 🎉
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The Pushlytic Android SDK is published on [Maven Central](https://search.maven.o
 1. Add the Pushlytic Android SDK dependency to your `build.gradle` file:
    ```kotlin
    dependencies {
-       implementation("com.pushlytic:sdk:0.1.0")
+       implementation("com.pushlytic:sdk:0.1.1")
    }
    ```
 2. Sync your project with Gradle files.

--- a/sdk/build.gradle.kts
+++ b/sdk/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
     id("signing")
 }
 
-val pushlyticVersion = "0.1.0"
+val pushlyticVersion = "0.1.1"
 val dotenv = Dotenv.configure().ignoreIfMissing().load()
 
 if (dotenv["OSSRH_USERNAME"].isNullOrEmpty() || dotenv["OSSRH_PASSWORD"].isNullOrEmpty()) {

--- a/sdk/src/main/java/com/pushlytic/sdk/Pushlytic.kt
+++ b/sdk/src/main/java/com/pushlytic/sdk/Pushlytic.kt
@@ -78,6 +78,7 @@ import kotlinx.coroutines.sync.withLock
  * @since 1.0.0
  */
 object Pushlytic: MessageStreamListener {
+    private lateinit var application: Application
     private val mutex = Mutex()
     private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
     private val mainHandler = Handler(Looper.getMainLooper())
@@ -151,6 +152,7 @@ object Pushlytic: MessageStreamListener {
         scope.launch {
             mutex.withLock {
                 cleanup()
+                this@Pushlytic.application = application
                 storedApiKey = configuration.apiKey
                 if (initializeClient(storedApiKey)) {
                     initializeLifecycleManager()
@@ -390,7 +392,7 @@ object Pushlytic: MessageStreamListener {
         if (apiKey.isNullOrEmpty()) {
             return false
         }
-        apiClient = ApiClientImpl()
+        apiClient = ApiClientImpl(application)
         apiClient?.apiKey = apiKey
         return true
     }


### PR DESCRIPTION
# Add Device ID to Android gRPC Metadata

## Changes
- Added device ID to Android gRPC metadata to match iOS implementation
- Using `ANDROID_ID` as the device identifier since it:
  - Persists through app restarts/updates
  - Only resets on factory reset
  - Requires no additional permissions

## Implementation Details
- Added Application context to ApiClientImpl constructor
- Used lazy initialization to cache device ID
- Added fallback to UUID in rare case of empty ANDROID_ID
- Added device ID to gRPC metadata headers