### PR TITLE
fix: handle null device id in tests

### DIFF
--- a/sdk/src/main/java/com/pushlytic/sdk/ApiClientImpl.kt
+++ b/sdk/src/main/java/com/pushlytic/sdk/ApiClientImpl.kt
@@ -93,7 +93,11 @@ class ApiClientImpl(
     private val deviceId: String by lazy {
         @SuppressLint("HardwareIds")
         val id = Settings.Secure.getString(application.contentResolver, Settings.Secure.ANDROID_ID)
-        id.ifEmpty { UUID.randomUUID().toString() }
+        if (id.isNullOrEmpty()) {
+            UUID.randomUUID().toString()
+        } else {
+            id
+        }
     }
 
     init {


### PR DESCRIPTION
# Fix Device ID Handling in Tests

- Modified device ID initialization to handle null cases
- Used `isNullOrEmpty()` check instead of `ifEmpty`
- Maintained UUID fallback for both null and empty cases