### PR TITLE
feat: migrate to kotlinx.serialization for JSON parsing and support metadata on initial connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 All notable changes to the Pushlytic Android SDK will be documented in this file.
 
+## [0.1.3] - 2025-02-08
+### Added
+- **Metadata Support for Initial Connection**
+    - Added ability to include metadata when opening a connection via `openMessageStream(metadata:)`
+    - Updates parseMessage function to support the @Serializable api
+
 ## [0.1.2] - 2025-02-02
 ### Changed
 - Adjusted TLS connection management for improved stability

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The Pushlytic Android SDK is published on [Maven Central](https://search.maven.o
 1. Add the Pushlytic Android SDK dependency to your `build.gradle` file:
    ```kotlin
    dependencies {
-       implementation("com.pushlytic:sdk:0.1.2")
+       implementation("com.pushlytic:sdk:0.1.3")
    }
    ```
 2. Sync your project with Gradle files.

--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.compose.compiler)
+    kotlin("plugin.serialization") version "2.1.10"
 }
 
 android {
@@ -58,6 +59,7 @@ dependencies {
     implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.androidx.navigation.compose)
+    implementation(libs.kotlinx.serialization.json.v180)
     implementation(project(":sdk"))
 
     testImplementation(libs.junit)

--- a/example/src/main/java/com/pushlytic/example/MainViewModel.kt
+++ b/example/src/main/java/com/pushlytic/example/MainViewModel.kt
@@ -5,7 +5,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import com.pushlytic.sdk.Pushlytic
 import com.pushlytic.sdk.model.ConnectionStatus
-import org.json.JSONObject
+import kotlinx.serialization.Serializable
 
 data class UserInfo(
     val userId: String,
@@ -15,6 +15,7 @@ data class UserInfo(
     val premiumStatus: Boolean
 )
 
+@Serializable
 data class MessageData(
     val address: Address?,
     val age: Int,
@@ -25,6 +26,7 @@ data class MessageData(
     val preferences: Preferences
 )
 
+@Serializable
 data class Address(
     val city: String,
     val state: String,
@@ -32,12 +34,14 @@ data class Address(
     val zip: String
 )
 
+@Serializable
 data class Marketing(
     val email: String,
     val message: String,
     val name: String
 )
 
+@Serializable
 data class Preferences(
     val newsletter: Boolean,
     val notifications: Boolean
@@ -121,9 +125,9 @@ class MainViewModel : ViewModel() {
     private fun handleMessageReceived(jsonString: String) {
         Pushlytic.parseMessage(
             message = jsonString,
-            type = MessageData::class.java,
-            completion = { messageData ->
-                _currentMessage.postValue(messageData)
+            serializer = MessageData.serializer(),
+            completion = { data ->
+                _currentMessage.postValue(data)
                 _showingMessage.postValue(true)
             },
             errorHandler = { error ->

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ dotenvKotlin = "6.4.1"
 grpcAndroid = "1.58.0"
 gson = "2.10.1"
 javaxAnnotationApi = "1.3.2"
+jetbrainsKotlinxSerializationJson = "1.8.0"
 kotlin = "2.0.0"
 coreKtx = "1.15.0"
 junit = "4.13.2"
@@ -18,6 +19,8 @@ kotlinTest = "1.9.10"
 kotlinxCoroutinesAndroid = "1.7.3"
 kotlinxCoroutinesCore = "1.7.3"
 kotlinxCoroutinesTest = "1.7.3"
+kotlinxSerializationJson = "1.3.2"
+kotlinxSerializationJsonVersion = "1.6.3"
 lifecycleCommonJava8 = "2.6.1"
 lifecycleProcess = "2.8.7"
 lifecycleRuntimeKtx = "2.8.7"
@@ -76,6 +79,9 @@ kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotl
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinxCoroutinesAndroid" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutinesCore" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTest" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
+kotlinx-serialization-json-v163 = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJsonVersion" }
+kotlinx-serialization-json-v180 = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "jetbrainsKotlinxSerializationJson" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "nav-compose" }
 androidx-compose-runtime-livedata = { group = "androidx.compose.runtime", name = "runtime-livedata", version.ref = "compose-runtime" }

--- a/sdk/build.gradle.kts
+++ b/sdk/build.gradle.kts
@@ -4,13 +4,14 @@ plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.compose.compiler)
+    kotlin("plugin.serialization") version "1.9.21"
     id("com.google.protobuf")
     id("maven-publish")
     id("org.jetbrains.dokka")
     id("signing")
 }
 
-val pushlyticVersion = "0.1.2"
+val pushlyticVersion = "0.1.3"
 val dotenv = Dotenv.configure().ignoreIfMissing().load()
 
 if (dotenv["OSSRH_USERNAME"].isNullOrEmpty() || dotenv["OSSRH_PASSWORD"].isNullOrEmpty()) {
@@ -90,7 +91,7 @@ android {
 
 dependencies {
     coreLibraryDesugaring(libs.desugar.jdk.libs)
-
+    implementation(libs.kotlinx.serialization.json.v180)
     // Compose dependencies
     implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.androidx.lifecycle.process)
@@ -121,6 +122,7 @@ dependencies {
     testImplementation(libs.robolectric.v4141)
     testImplementation(libs.mockk)
     testImplementation(libs.androidx.core)
+    testImplementation(libs.kotlinx.serialization.json.v180)
 }
 
 protobuf {

--- a/sdk/src/main/java/com/pushlytic/sdk/server/interfaces/APIClient.kt
+++ b/sdk/src/main/java/com/pushlytic/sdk/server/interfaces/APIClient.kt
@@ -59,10 +59,24 @@ interface ApiClient {
     /**
      * Opens a message stream to communicate with the server.
      *
-     * - Establishes a bi-directional streaming connection.
-     * - Starts listening for incoming messages and state changes.
+     * @param metadata Optional metadata to include with the initial connection. Can contain
+     * additional information about the connection or user that may be useful for server-side
+     * processing or workflows.
+     *
+     * Example usage:
+     * ```kotlin
+     * // Basic connection
+     * Pushlytic.openMessageStream()
+     *
+     * // Connection with metadata
+     * Pushlytic.openMessageStream(metadata = mapOf(
+     *     "user_type" to "premium",
+     *     "app_version" to "2.1.0",
+     *     "device_language" to "en-US"
+     * ))
+     * ```
      */
-    fun openMessageStream()
+    fun openMessageStream(metadata: Map<String, Any>? = null)
 
     /**
      * Ends the current message stream connection.

--- a/sdk/src/test/java/com/pushlytic/sdk/mocks/MockAPIClient.kt
+++ b/sdk/src/test/java/com/pushlytic/sdk/mocks/MockAPIClient.kt
@@ -29,7 +29,7 @@ class MockApiClient(override var apiKey: String?) : ApiClient {
         this.listener = listener
     }
 
-    override fun openMessageStream() {
+    override fun openMessageStream(metadata: Map<String, Any>?) {
         isConnected = true
         listener?.onStateChanged(MessageStreamState.Connected)
     }


### PR DESCRIPTION
- Add Kotlin serialization plugin for compile-time serializer generation
- Update parseMessage API to use KSerializer instead of Class<T>
- Update documentation with @Serializable examples
- Update tests to use new serialization API
- Remove Gson-based JSON parsing
- Adds support for adding metadata on initial open stream request